### PR TITLE
[fix] fixed karma tests on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # type-vein
 Strictly typed data framework for consuming HTTP services
+
+# FAQ
+
+##
+
+**Q:** I have the following error when I try to 
+```bash
+$ npm run test
+```
+No binary for ChromeHeadless browser on your platform.
+Please, set "CHROME_BIN" env variable.
+
+**A:** You have to set the CHROME_BIN variable, in linux you can execute this in terminal:
+```bash
+$ export CHROME_BIN=/usr/local/bin/my-chrome-build
+```
+More details for running karma with different browsers can be found [here](http://karma-runner.github.io/4.0/config/browsers.html)
+##
+
+Template:
+
+**Q:**
+
+**A:**
+##

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,9 +1,9 @@
 let npmCommand = process.env.npm_lifecycle_event;
 
-let browsers = ["ChromeHeadless"];
+let browsers = ["ChromeHeadless", "Chromium"];
 
 if (npmCommand.includes(":watch")) {
-    browsers = ["Chrome"];
+    browsers = ["Chrome", "Chromium"];
 }
 
 module.exports = function (config) {


### PR DESCRIPTION
npm run test didnt work in case chromium is used instead of chrome. Added chromium as a browser to run the tests. Described in readme how to fix similar errors.