### PR TITLE
feat: unit tests should run on both linux and windows

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,6 @@
 let npmCommand = process.env.npm_lifecycle_event;
+process.env.CHROME_BIN  =  require('puppeteer').executablePath();
+
 let browsers = ["ChromeHeadless"];
 let reporters = ["mocha"];
 let withCoverage = true;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test": "karma start --single-run",
         "test:watch": "karma start",
         "test:debug": "karma start",
-        "prepublish": "npm run build && npm run test",
+        "npmprepublish": "npm run build && npm run test",
         "lint": "tslint --project ."
     },
     "peerDependencies": {},
@@ -31,7 +31,8 @@
         "karma-mocha-reporter": "2.2.5",
         "karma-sourcemap-loader": "0.3.7",
         "karma-webpack": "4.0.2",
-        "rimraf": "3.0.0",
+        "puppeteer": "2.0.0",
+        "rimraf": "3.0.0",        
         "ts-loader": "6.2.1",
         "tslint": "5.20.1",
         "typescript": "3.7.3",

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,29 @@
 # type-vein
-Strictly typed data framework for consuming HTTP services.
+Strictly typed data framework for consuming HTTP services. cache hit test.
+# FAQ
 
-This library is WIP and not yet usable.
-
-## purpose
-The goal is to create a library that provides:
-- a common interface to execute CRUD operations, no matter where your data is accessed from
-- strict typing of your data, so that errors are caught during compilation
-- caching to reduce HTTP calls, which also allows developers to choose a more functional programming approach
-
-## usage
-as of now all you can do is clone and run the tests, so that'll be
+**Q:** I have the following error when I try to 
+```bash
+$ npm run test
 ```
-npm i
-npm test
+No binary for ChromeHeadless browser on your platform.
+Please, set "CHROME_BIN" env variable.
+
+**A:** You have to set the CHROME_BIN variable, in linux you can execute this in terminal:
+```bash
+$ export CHROME_BIN=/usr/local/bin/my-chrome-build
 ```
+More details for running karma with different browsers can be found [here](http://karma-runner.github.io/4.0/config/browsers.html) .
+**Note:** puppeteer should fix this issue consistently on all the OSes, so feel free to create an issue in case it didnt work for you out of the box.
+##
+
+**Q:** Why is prepublish called npm prepublish?
+
+**A:** Npm doesnt distinguish between npm install and prepublish. See more details [here](https://github.com/npm/npm/issues/3059)
+##
+
+Template:
+
+**Q:**
+
+**A:**


### PR DESCRIPTION
Unit tests should run the same way on linux and windows now. Actually as per readme its only relevant for the systems with no CHROME_BIN variable set, which is mostly linux where main browser is Firefox.